### PR TITLE
Skip registered_user and organization tests in CI environment 

### DIFF
--- a/spec/sys_uname_spec.rb
+++ b/spec/sys_uname_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe Sys::Uname do
       expect(described_class.uname.number_of_users).to be_kind_of(Integer)
     end
 
-    example "organization" do
+    example "organization", :unless => ENV['CI'] do
       expect{ described_class.uname.organization }.not_to raise_error
       expect(described_class.uname.organization).to be_kind_of(String)
     end
@@ -371,7 +371,7 @@ RSpec.describe Sys::Uname do
       expect(described_class.uname.quantum_type).to be_kind_of(Integer).or be_nil
     end
 
-    example "registered_user" do
+    example "registered_user", :unless => ENV['CI'] do
       expect{ described_class.uname.registered_user }.not_to raise_error
       expect(described_class.uname.registered_user).to be_kind_of(String)
     end


### PR DESCRIPTION
A Windows test environment may not set the `registered_user` or `organization` attributes, so skip those tests if the `CI` env variable is detected.