### PR TITLE
Add Dragonfly support, remove Solaris

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,20 +27,6 @@ p Sys::Platform.linux? # => true
 p Sys::Platform::ARCH  # => :x86_64
 ```
    
-## Solaris Notes
-Users on SunOS get several extra methods:
-
-* architecture
-* platform
-* hw_serial
-* hw_provider
-* srpc_domain
-* isa_list
-* dhcp_cache
-
-Note that Solaris is essentially a dead OS at this point, so it will not be
-supported going forward, and will likely be dropped in the next major release.
-
 ## BSD flavors, including OS X
 Users on BSD platforms get the extra `Uname.model` method.
 

--- a/doc/uname.rdoc
+++ b/doc/uname.rdoc
@@ -26,7 +26,7 @@ VERSION
 
 == Class Methods
 Uname.sysname
-  Returns the operating system name, e.g. "SunOS"
+  Returns the operating system name, e.g. "Darwin".
     
 Uname.nodename
   Returns the nodename. This is usually, but not necessarily, the 
@@ -48,40 +48,11 @@ Uname.release
     
 Uname.uname
   Returns a struct of type UnameStruct that contains sysname, nodename,
-  machine, version, and release. On Solaris, it will also include 
-  architecture and platform. On HP-UX, it will also include id_number.
+  machine, version, and release. On HP-UX, it will also include id_number.
     
   MS Windows - there are many more, and different, fields in the struct.
   Please see the MSDN documenation on the Win32_OperatingSystem WMI class
   for a complete explanation of what each of these members mean.
-    
-== Solaris Only
-Uname.architecture
-  Returns the instruction set architecture, e.g. "sparc"
-    
-Uname.platform
-  Returns the platform identifier, e.g. "SUNW,Sun-Blade-100"
-    
-Uname.isa_list
-  Returns a space separated string containing a list of all variant
-  instruction set architectures executable on the current system.
- 
-  They are listed in order of performance, from best to worst.
-
-Uname.hw_provider
-  Returns the name of the hardware manufacturer.
-
-Uname.hw_serial_number
-  Returns the ASCII representation of the hardware-specific serial number
-  of the machine that executes the function.
-
-Uname.srpc_domain
-  Returns the name of the Secure Remote Procedure Call domain, if any.
-
-Uname.dhcp_cache
-  Returns a hexidecimal encoding, in String form, of the name of the
-  interface configured by boot(1M) followed by the DHCPACK reply from
-  the server.
     
 == BSD Platforms Only (including OS X)
 Uname.model
@@ -105,14 +76,11 @@ UnameStruct members mean.
 None that I'm aware of. Please log any bugs on the project page at
 https://github.com/djberg96/sys-uname 
 	
-== Future Plans
-Add additional info for Linux, Solaris, BSD.
-
 == License
 Apache-2.0
 
 == Copyright
-(C) 2002-2023 Daniel J. Berger
+(C) 2002-2024 Daniel J. Berger
 All Rights Reserved
 
 == Warranty

--- a/examples/uname_test.rb
+++ b/examples/uname_test.rb
@@ -15,19 +15,7 @@ puts 'Version: ' + Uname.version
 puts 'Release: ' + Uname.release
 puts 'Machine: ' + Uname.machine # May be "unknown" on Win32
 
-if RbConfig::CONFIG['host_os'] =~ /sun|solaris/i
-  print "\nSolaris specific tests\n"
-  puts "==========================="
-  puts 'Architecture: ' + Uname.architecture
-  puts 'Platform: ' + Uname.platform
-  puts 'Instruction Set List: ' + Uname.isa_list.split.join(", ")
-  puts 'Hardware Provider: ' + Uname.hw_provider
-  puts 'Serial Number: ' + Uname.hw_serial_number.to_s
-  puts 'SRPC Domain: ' + Uname.srpc_domain # might be empty
-  puts 'DHCP Cache: ' + Uname.dhcp_cache # might be empty
-end
-
-if RbConfig::CONFIG['host_os'] =~ /powerpc|darwin|bsd|mach/i
+if RbConfig::CONFIG['host_os'] =~ /powerpc|darwin|bsd|dragonfly|mach/i
   print "\nBSD/OS X specific tests\n"
   puts "======================="
   puts 'Model: ' + Uname.model

--- a/lib/sys/platform.rb
+++ b/lib/sys/platform.rb
@@ -19,9 +19,7 @@ module Sys
                RbConfig::CONFIG['host_os'].split('_').first[/[a-z]+/i].downcase.to_sym
              when /linux/i
                :linux
-             when /sunos|solaris/i
-               :solaris
-             when /bsd/i
+             when /bsd|dragonfly/i
                :bsd
            end
 
@@ -43,11 +41,6 @@ module Sys
     # Returns whether or not you're on Linux
     def self.linux?
       Uname.sysname =~ /linux/i ? true : false
-    end
-
-    # Returns whether or not you're on Solaris
-    def self.solaris?
-      Uname.sysname =~ /sunos|solaris/i ? true : false
     end
 
     # Returns whether or not you're on any BSD platform

--- a/lib/sys/unix/uname.rb
+++ b/lib/sys/unix/uname.rb
@@ -20,7 +20,7 @@ module Sys
     case RbConfig::CONFIG['host_os']
       when /linux/i
         BUFSIZE = 65
-      when /bsd/i
+      when /bsd|dragonfly/i
         BUFSIZE = 32 # TODO: version method chopped
       when /sunos|solaris/i
         BUFSIZE = 257
@@ -100,7 +100,7 @@ module Sys
       )
     end
 
-    fields.push('model') if RbConfig::CONFIG['host_os'] =~ /darwin|bsd/i
+    fields.push('model') if RbConfig::CONFIG['host_os'] =~ /darwin|bsd|dragonfly/i
 
     private_constant :UnameFFIStruct
 
@@ -135,27 +135,8 @@ module Sys
       struct[:version]  = utsname[:version].to_s
       struct[:machine]  = utsname[:machine].to_s
 
-      struct[:model] = get_model() if RbConfig::CONFIG['host_os'] =~ /darwin|bsd/i
-
-      if RbConfig::CONFIG['host_os'] =~ /sunos|solaris/i
-        struct[:architecture] = get_si(SI_ARCHITECTURE)
-        struct[:platform]     = get_si(SI_PLATFORM)
-        struct[:hw_serial]    = get_si(SI_HW_SERIAL)
-        struct[:hw_provider]  = get_si(SI_HW_PROVIDER)
-        struct[:srpc_domain]  = get_si(SI_SRPC_DOMAIN)
-        struct[:isa_list]     = get_si(SI_ISALIST)
-        struct[:dhcp_cache]   = get_si(SI_DHCP_CACHE)
-
-        # FFI and Solaris don't get along so well, so we try again
-        struct[:sysname]  = get_si(SI_SYSNAME) if struct.sysname.empty?
-        struct[:nodename] = get_si(SI_HOSTNAME) if struct.nodename.empty?
-        struct[:release]  = get_si(SI_RELEASE) if struct.release.empty?
-        struct[:version]  = get_si(SI_VERSION) if struct.version.empty?
-        struct[:machine]  = get_si(SI_MACHINE) if struct.machine.empty?
-      end
-
+      struct[:model] = get_model() if RbConfig::CONFIG['host_os'] =~ /darwin|bsd|dragonfly/i
       struct[:id_number] = utsname[:__id_number].to_s if RbConfig::CONFIG['host_os'] =~ /hpux/i
-
       struct[:domainname] = utsname[:domainname].to_s if RbConfig::CONFIG['host_os'] =~ /linux/i
 
       # Let's add a members method that works for testing and compatibility
@@ -298,15 +279,5 @@ module Sys
     end
 
     private_class_method :get_model
-
-    # Returns the various sysinfo information based on +flag+.
-    #
-    def self.get_si(flag)
-      buf = 0.chr * BUFSIZE
-      sysinfo(flag, buf, BUFSIZE)
-      buf.strip
-    end
-
-    private_class_method :get_si
   end
 end

--- a/lib/sys/unix/uname.rb
+++ b/lib/sys/unix/uname.rb
@@ -21,9 +21,7 @@ module Sys
       when /linux/i
         BUFSIZE = 65
       when /bsd|dragonfly/i
-        BUFSIZE = 32 # TODO: version method chopped
-      when /sunos|solaris/i
-        BUFSIZE = 257
+        BUFSIZE = 32
       else
         BUFSIZE = 256
     end
@@ -87,19 +85,6 @@ module Sys
 
     fields.push('domainname') if RbConfig::CONFIG['host_os'] =~ /linux/i
     fields.push('id_number') if RbConfig::CONFIG['host_os'] =~ /hpux/i
-
-    if RbConfig::CONFIG['host_os'] =~ /sunos|solaris/i
-      fields.push(
-        'architecture',
-        'dhcp_cache',
-        'hw_provider',
-        'hw_serial',
-        'isa_list',
-        'platform',
-        'srpc_domain'
-      )
-    end
-
     fields.push('model') if RbConfig::CONFIG['host_os'] =~ /darwin|bsd|dragonfly/i
 
     private_constant :UnameFFIStruct
@@ -111,9 +96,7 @@ module Sys
     # Returns a struct that contains the sysname, nodename, machine, version
     # and release of your system.
     #
-    # On OS X it will also include the model.
-    #
-    # On Solaris, it will also include the architecture and platform.
+    # On OS X and BSD platforms it will also include the model.
     #
     # On HP-UX, it will also include the id_number.
     #
@@ -155,7 +138,7 @@ module Sys
     #
     # Example:
     #
-    #  Uname.sysname # => 'SunOS'
+    #  Uname.sysname # => 'Darwin'
     #
     def self.sysname
       uname.sysname

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ require 'rspec'
 require 'sys/uname'
 
 RSpec.configure do |config|
-  config.filter_run_excluding(:solaris) unless RbConfig::CONFIG['host_os'] =~ /sunos|solaris/i
   config.filter_run_excluding(:bsd) unless RbConfig::CONFIG['host_os'] =~ /powerpc|darwin|macos|bsd|dragonfly/i
   config.filter_run_excluding(:hpux) unless RbConfig::CONFIG['host_os'] =~ /hpux/i
   config.filter_run_excluding(:linux) unless RbConfig::CONFIG['host_os'] =~ /linux/i

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'sys/uname'
 
 RSpec.configure do |config|
   config.filter_run_excluding(:solaris) unless RbConfig::CONFIG['host_os'] =~ /sunos|solaris/i
-  config.filter_run_excluding(:bsd) unless RbConfig::CONFIG['host_os'] =~ /powerpc|darwin|macos|bsd/i
+  config.filter_run_excluding(:bsd) unless RbConfig::CONFIG['host_os'] =~ /powerpc|darwin|macos|bsd|dragonfly/i
   config.filter_run_excluding(:hpux) unless RbConfig::CONFIG['host_os'] =~ /hpux/i
   config.filter_run_excluding(:linux) unless RbConfig::CONFIG['host_os'] =~ /linux/i
   config.filter_run_excluding(:windows) unless Gem.win_platform?

--- a/spec/sys_platform_spec.rb
+++ b/spec/sys_platform_spec.rb
@@ -52,11 +52,6 @@ RSpec.describe Sys::Platform do
     expect(described_class.unix?).not_to eql(Gem.win_platform?)
   end
 
-  example 'the solaris? method is defined and returns a boolean' do
-    expect(described_class).to respond_to(:solaris?)
-    expect(described_class.solaris?).to eql(true).or eql(false)
-  end
-
   example 'the linux? method is defined and returns a boolean' do
     expect(described_class).to respond_to(:linux?)
     expect(described_class.linux?).to eql(true).or eql(false)

--- a/spec/sys_uname_spec.rb
+++ b/spec/sys_uname_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe Sys::Uname do
       expect(described_class).to respond_to(:nodename)
       expect{ described_class.nodename }.not_to raise_error
       expect(described_class.nodename).to be_a(String)
-      expect(described_class.nodename.size).to be > 0
     end
 
     example 'release singleton method works as expected' do
@@ -68,50 +67,6 @@ RSpec.describe Sys::Uname do
       expect{ described_class.sysname }.not_to raise_error
       expect(described_class.sysname).to be_a(String)
       expect(described_class.sysname.size).to be > 0
-    end
-  end
-
-  context 'singleton methods for Solaris only', :solaris do
-    example 'architecture singleton method works as expected on solaris' do
-      expect(described_class).to respond_to(:architecture)
-      expect{ described_class.architecture }.not_to raise_error
-      expect(described_class.architecture).to be_a(String)
-    end
-
-    example 'platform singleton method works as expected on solaris' do
-      expect(described_class).to respond_to(:platform)
-      expect{ described_class.platform }.not_to raise_error
-      expect(described_class.platform).to be_a(String)
-    end
-
-    example 'isa_list singleton method works as expected on solaris' do
-      expect(described_class).to respond_to(:isa_list)
-      expect{ described_class.isa_list }.not_to raise_error
-      expect(described_class.isa_list).to be_a(String)
-    end
-
-    example 'hw_provider singleton method works as expected on solaris' do
-      expect(described_class).to respond_to(:hw_provider)
-      expect{ described_class.hw_provider }.not_to raise_error
-      expect(described_class.hw_provider).to be_a(String)
-    end
-
-    example 'hw_serial singleton method works as expected on solaris' do
-      expect(described_class).to respond_to(:hw_serial)
-      expect{ described_class.hw_serial }.not_to raise_error
-      expect(described_class.hw_serial).to be_a(Integer)
-    end
-
-    example 'srpc_domain singleton method works as expected on solaris' do
-      expect(described_class).to respond_to(:srpc_domain)
-      expect{ described_class.srpc_domain }.not_to raise_error
-      expect(described_class.srpc_domain).to be_a(String)
-    end
-
-    example 'dhcp_cache singleton method works as expected on solaris' do
-      expect(described_class).to respond_to(:dhcp_cache)
-      expect{ described_class.dhcp_cache }.not_to raise_error
-      expect(described_class.dhcp_cache).to be_a(String)
     end
   end
 
@@ -134,11 +89,6 @@ RSpec.describe Sys::Uname do
   context 'uname struct' do
     example 'uname struct contains expected members on linux', :linux do
       members.push(:domainname)
-      expect(described_class.uname.members.sort).to eql(members.sort)
-    end
-
-    example 'uname struct contains expected members on solaris', :solaris do
-      members.push(:architecture, :platform, :hw_serial, :hw_provider, :srpc_domain, :isa_list, :dhcp_cache)
       expect(described_class.uname.members.sort).to eql(members.sort)
     end
 


### PR DESCRIPTION
This PR adds DragonflyBSD support. This mainly consisted of adding 'dragonfly' to the various host OS string checks.

One test was removed because the nodename is not actually guaranteed to be set for a non-networked host.

Solaris was removed because it's dead.