### PR TITLE
Suppress a Ruby 3.3's warning

### DIFF
--- a/lib/sys/unix/uname.rb
+++ b/lib/sys/unix/uname.rb
@@ -2,7 +2,6 @@
 
 require 'ffi'
 require 'rbconfig'
-require 'ostruct'
 
 # The Sys module serves as a namespace only.
 module Sys


### PR DESCRIPTION
This PR suppresses the following warning:

```console
$ cd path/to/djberg96/sys-uname
$ ruby -v
ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [x86_64-darwin23]
$ bundle exec rake
(snip)

gems/3.3.0/gems/rspec-core-3.13.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
/Users/koic/src/github.com/djberg96/sys-uname/lib/sys/uname.rb:18: warning: ostruct was loaded from the standard library,
but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```

`OpenStruct` is no longer used as of commit https://github.com/djberg96/sys-uname/commit/790ffe9. Therefore, it is safe to remove `require 'ostruct'`.